### PR TITLE
Remove validation asymmetry

### DIFF
--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -238,9 +238,9 @@ For all parameter sets, the server MUST perform the encapsulation key check
 described in Section 7.2 of {{FIPS203}} on the client's encapsulation key,
 and abort with an `illegal_parameter` alert if it fails.
 
-For all parameter sets, the client MUST check if the ciphertext length
-matches the selected parameter set, and abort with an `illegal_parameter`
-alert if it fails.
+For all parameter sets, the client MUST perform the decapsulation input check
+described in Section 7.3 of {{FIPS203}} on the ciphertext, and abort with
+an `illegal_parameter` alert if it fails.
 
 If ML-KEM decapsulation fails for any other reason, the connection MUST be
 aborted with an `internal_error` alert.

--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -242,8 +242,8 @@ For all parameter sets, the client MUST perform the decapsulation input check
 described in Section 7.3 of {{FIPS203}} on the ciphertext, and abort with
 an `illegal_parameter` alert if it fails.
 
-If ML-KEM decapsulation fails for any other reason, the connection MUST be
-aborted with an `internal_error` alert.
+If ML-KEM encapsulation or decapsulation fails for any other reason,
+the connection MUST be aborted with an `internal_error` alert.
 
 Implementations MUST NOT reuse randomness in the generation of ML-KEM
 ciphertexts— it follows that ML-KEM ciphertexts also MUST NOT be reused.


### PR DESCRIPTION
This is one of those cases where the illegal_parameter alert might be impractical relative to internal_error.  This is because, in both cases, the checks involve operations that are more properly encapsulated in an mlkem module.  Having error reasons propagate out of that module is probably not a good idea in general, so it might be hard to generate the right error code.

But, if the server is doing the modulus check on pk, then the client can do a hash over dk.

So this is just one option.  I'll follow up with a different take.