### PR TITLE
Allow checks to generate internal_error

### DIFF
--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -234,16 +234,21 @@ output of the corresponding ML-KEM parameter set's `KeyGen` algorithm.
 For the server's share, the `key_exchange` value contains the `ct`
 output of the corresponding ML-KEM parameter set's `Encaps` algorithm.
 
-For all parameter sets, the server MUST perform the encapsulation key check
-described in Section 7.2 of {{FIPS203}} on the client's encapsulation key,
+For all parameter sets, the server MUST check if the encapsulation key (`pk`)
+matches the selected parameter set,
 and abort with an `illegal_parameter` alert if it fails.
 
-For all parameter sets, the client MUST check if the ciphertext length
-matches the selected parameter set, and abort with an `illegal_parameter`
-alert if it fails.
+For all parameter sets, the client MUST check if the ciphertext length (`ct`)
+matches the selected parameter set,
+and abort with an `illegal_parameter` alert if it fails.
 
-If ML-KEM decapsulation fails for any other reason, the connection MUST be
-aborted with an `internal_error` alert.
+Prior to encapsulation, the server MUST perform the encapsulation key check
+from Section 7.2 of {{FIPS203}}.
+Prior to decapsulation, the client MUST perform the decapsulation input check
+from Section 7.3 of {{FIPS203}}.
+
+If ML-KEM checks, encapsulation, or decapsulation fail for any other reason,
+the connection MUST be aborted with an `internal_error` alert.
 
 Implementations MUST NOT reuse randomness in the generation of ML-KEM
 ciphertexts— it follows that ML-KEM ciphertexts also MUST NOT be reused.

--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -234,7 +234,7 @@ output of the corresponding ML-KEM parameter set's `KeyGen` algorithm.
 For the server's share, the `key_exchange` value contains the `ct`
 output of the corresponding ML-KEM parameter set's `Encaps` algorithm.
 
-For all parameter sets, the server MUST check if the encapsulation key (`pk`)
+For all parameter sets, the server MUST check if the encapsulation key length (`pk`)
 matches the selected parameter set,
 and abort with an `illegal_parameter` alert if it fails.
 

--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -242,11 +242,6 @@ For all parameter sets, the client MUST check if the ciphertext length (`ct`)
 matches the selected parameter set,
 and abort with an `illegal_parameter` alert if it fails.
 
-Prior to encapsulation, the server MUST perform the encapsulation key check
-from Section 7.2 of {{FIPS203}}.
-Prior to decapsulation, the client MUST perform the decapsulation input check
-from Section 7.3 of {{FIPS203}}.
-
 If ML-KEM checks, encapsulation, or decapsulation fail for any other reason,
 the connection MUST be aborted with an `internal_error` alert.
 


### PR DESCRIPTION
This alternative is the one I prefer, because it ensures that the MLKEM stuff is kept within the boundary.  ANY failure in that module results in the same `internal_error` abort.  There is a redundant check for the size of the key share, but that seems tolerable.

Note that this version allows the `internal_error` statement to be a lot cleaner.

Closes #24.