### PR TITLE
Compact the registration

### DIFF
--- a/draft-ietf-tls-mlkem.md
+++ b/draft-ietf-tls-mlkem.md
@@ -312,7 +312,7 @@ Supported Group) registry, according to the procedures in {{Section 6 of
 
  Comment:
  : FIPS 203 version of ML-KEM-512
-
+{:compact}
 
 
  Value:
@@ -332,7 +332,7 @@ Supported Group) registry, according to the procedures in {{Section 6 of
 
  Comment:
  : FIPS 203 version of ML-KEM-768
-
+{:compact}
 
 
  Value:
@@ -352,6 +352,7 @@ Supported Group) registry, according to the procedures in {{Section 6 of
 
  Comment:
  : FIPS 203 version of ML-KEM-1024
+{:compact}
 
 
 --- back


### PR DESCRIPTION
Otherwise they just sort of run together.

The alternative is to use a table, which might be better in this case.